### PR TITLE
Add developers details and project name for the pom file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+  
+  <name>Dockerunit Parent Pom</name>
+  
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.github.dockerunit</groupId>
@@ -17,7 +19,26 @@
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-
+  
+  <developers>
+    <developer>
+      <id>qzagarese</id>
+      <name>Quirino Zagarese</name>
+    </developer>
+    <developer>
+      <id>pnsantos</id>
+      <name>Pedro Nuno Santos</name>
+    </developer>
+    <developer>
+      <id>irotech</id>
+      <name>Vincenzo Candela</name>
+    </developer>
+    <developer>
+      <id>DarthSeppius</id>
+      <name>Francesco Sorice</name>
+    </developer>
+  </developers>
+  
   <scm>
     <connection>scm:https://github.com/dockerunit/dockerunit-parent.git</connection>
     <developerConnection>scm:https://github.com/dockerunit/dockerunit-parent.git</developerConnection>


### PR DESCRIPTION
Signed-off-by: fsorice <fsorice89@gmail.com>

This is necessary for the maven deployer for deploying the artifact on nexus since we got this error during the build:

```
[ERROR] Rule failure while trying to close staging repository with ID "comgithubdockerunit-1000".
[ERROR] 
[ERROR] Nexus Staging Rules Failure Report
[ERROR] ==================================
[ERROR] 
[ERROR] Repository "comgithubdockerunit-1000" failures
[ERROR]   Rule "pom-staging" failures
[ERROR]     * Invalid POM: /com/github/dockerunit/dockerunit-parent/0.1.0/dockerunit-parent-0.1.0.pom: Project name missing, Developer information missing
[ERROR] 
[ERROR] 
[ERROR] Cleaning up local stage directory after a Rule failure during close of staging repositories: [comgithubdockerunit-1000]
[ERROR]  * Deleting context a52b7c9602a99f.properties
[ERROR] Cleaning up remote stage repositories after a Rule failure during close of staging repositories: [comgithubdockerunit-1000]
[ERROR]  * Dropping failed staging repository with ID "comgithubdockerunit-1000" (Rule failure during close of staging repositories: [comgithubdockerunit-1000]).
```