### PR TITLE
Bumping to 0.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
-    <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
+    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <flatten-maven-plugin.version>1.2.1</flatten-maven-plugin.version>
     <enforcer-extra-rules.version>1.2</enforcer-extra-rules.version>
     <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
 
     <!-- Other Plugins -->
-    <flatten-maven-plugin.version>1.1.0</flatten-maven-plugin.version>
+    <flatten-maven-plugin.version>1.2.1</flatten-maven-plugin.version>
     <enforcer-extra-rules.version>1.2</enforcer-extra-rules.version>
     <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </distributionManagement>
 
   <properties>
-    <revision>0.1.0</revision>
+    <revision>0.2.0-SNAPSHOT</revision>
 
     <maven.min.version>3.6.0</maven.min.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+    <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
 
     <!-- Other Plugins -->
     <flatten-maven-plugin.version>1.2.1</flatten-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <jacoco.exec.datafile>${project.build.directory}/coverage-reports/jacoco-ut.exec</jacoco.exec.datafile>
 
     <!-- Dependency Management -->
-    <slf4j.version>1.7.26</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
 
     <!-- Maven Plugins -->
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>


### PR DESCRIPTION
This unlocks the API changes for ServiceInstance in core which are summarised hereafter:
- deprecate `getIp` in favour of `getGatewayAddress`
- deprecate `getPort` in favour of `getGatewayPort`

These changes are in https://github.com/dockerunit/dockerunit-core/pull/8 and https://github.com/dockerunit/dockerunit-consul/pull/11

Collectively, these changes unlock a potential release for https://github.com/dockerunit/dockerunit-deployer-maven-plugin